### PR TITLE
Fix svg migration when we are already under the size limit

### DIFF
--- a/src/entrypoints/ConfigScreen/ConfigScreen.tsx
+++ b/src/entrypoints/ConfigScreen/ConfigScreen.tsx
@@ -91,6 +91,12 @@ export default function ConfigScreen({ ctx }: Props) {
     setIsMigrating(true)
 
     try {
+      // Log backup of all SVGs before migration in case of failure
+      console.info(
+        `[Everything SVG] Backing up ${svgsToMigrate.length} SVG(s) before migration. Copy this data if you need to recover:`,
+        JSON.stringify(svgsToMigrate),
+      )
+
       const migrated = await migrateSvgsToRecords(
         ctx.currentUserAccessToken!,
         pluginParameters.svgModelId,
@@ -157,6 +163,11 @@ export default function ConfigScreen({ ctx }: Props) {
       const svgsToMigrate = pluginParameters.svgs || []
       let migratedCount = 0
       if (svgsToMigrate.length > 0) {
+        // Log backup of all SVGs before migration in case of failure
+        console.info(
+          `[Everything SVG] Backing up ${svgsToMigrate.length} SVG(s) before migration. Copy this data if you need to recover:`,
+          JSON.stringify(svgsToMigrate),
+        )
         const migrated = await migrateSvgsToRecords(
           apiToken,
           model.id,

--- a/src/entrypoints/ConfigScreen/ConfigScreen.tsx
+++ b/src/entrypoints/ConfigScreen/ConfigScreen.tsx
@@ -91,21 +91,30 @@ export default function ConfigScreen({ ctx }: Props) {
     setIsMigrating(true)
 
     try {
-      await migrateSvgsToRecords(
+      const migrated = await migrateSvgsToRecords(
         ctx.currentUserAccessToken!,
         pluginParameters.svgModelId,
         svgsToMigrate,
       )
 
-      // Clear the parameter-based SVGs after successful migration
+      const failedCount = svgsToMigrate.length - migrated.length
+
+      // Clear the parameter-based SVGs after migration
+      const { svgs: _oldSvgs, ...restParams } = pluginParameters
       await ctx.updatePluginParameters({
-        ...pluginParameters,
+        ...restParams,
         svgs: [],
       })
 
-      ctx.notice(
-        `Successfully migrated ${svgsToMigrate.length} SVG(s) to records!`,
-      )
+      if (failedCount > 0) {
+        ctx.alert(
+          `${migrated.length} SVG(s) migrated successfully, but ${failedCount} failed. Check the browser console for details.`,
+        )
+      } else {
+        ctx.notice(
+          `Successfully migrated ${migrated.length} SVG(s) to records!`,
+        )
+      }
     } catch (error) {
       console.error('Migration error:', error)
       ctx.alert(
@@ -130,14 +139,7 @@ export default function ConfigScreen({ ctx }: Props) {
     setIsCreatingModel(true)
 
     try {
-      const apiToken = ctx.currentUserAccessToken
-
-      if (!apiToken) {
-        ctx.alert(
-          'API token not available. You may need to configure this manually.',
-        )
-        return
-      }
+      const apiToken = ctx.currentUserAccessToken!
 
       // Only pass environment if it's not a UI navigation state
       const envToPass =
@@ -153,9 +155,17 @@ export default function ConfigScreen({ ctx }: Props) {
 
       // Migrate existing svgs to records before saving parameters
       const svgsToMigrate = pluginParameters.svgs || []
+      let migratedCount = 0
       if (svgsToMigrate.length > 0) {
-        await migrateSvgsToRecords(apiToken, model.id, svgsToMigrate)
+        const migrated = await migrateSvgsToRecords(
+          apiToken,
+          model.id,
+          svgsToMigrate,
+        )
+        migratedCount = migrated.length
       }
+
+      const failedCount = svgsToMigrate.length - migratedCount
 
       // Save parameters without old svgs array to stay under size limit
       const { svgs: _oldSvgs, ...restParams } = pluginParameters
@@ -165,11 +175,17 @@ export default function ConfigScreen({ ctx }: Props) {
         isSetupComplete: true,
       })
 
-      const message =
-        svgsToMigrate.length > 0
-          ? `SVG model created and ${svgsToMigrate.length} SVG(s) migrated!`
-          : 'SVG model created successfully!'
-      ctx.notice(message)
+      if (failedCount > 0) {
+        ctx.alert(
+          `SVG model created. ${migratedCount} SVG(s) migrated successfully, but ${failedCount} failed. Check the browser console for details.`,
+        )
+      } else if (migratedCount > 0) {
+        ctx.notice(
+          `SVG model created and ${migratedCount} SVG(s) migrated successfully!`,
+        )
+      } else {
+        ctx.notice('SVG model created successfully!')
+      }
     } catch (err) {
       console.error('Error creating model:', err)
       ctx.alert(

--- a/src/entrypoints/ConfigScreen/ConfigScreen.tsx
+++ b/src/entrypoints/ConfigScreen/ConfigScreen.tsx
@@ -2,11 +2,11 @@ import { useMemo, useState } from 'react'
 
 import { RenderConfigScreenCtx } from 'datocms-plugin-sdk'
 import {
+  Button,
   Canvas,
   Form,
   SelectField,
   FieldGroup,
-  Button,
   Spinner,
 } from 'datocms-react-ui'
 import {
@@ -17,7 +17,11 @@ import {
 } from '../../lib/types'
 import { pageTypeOptions, placementOptions } from '../../lib/constants'
 import { getMenuItemPlacements } from '../../lib/helpers'
-import { migrateSvgsToRecords, createSvgModel } from '../../lib/modelHelpers'
+import {
+  migrateSvgsToRecords,
+  createSvgModel,
+  checkIfModelExists,
+} from '../../lib/modelHelpers'
 
 type Props = {
   ctx: RenderConfigScreenCtx
@@ -141,16 +145,31 @@ export default function ConfigScreen({ ctx }: Props) {
           ? ctx.environment
           : undefined
 
-      const model = await createSvgModel(apiToken, envToPass)
+      // Reuse existing model if it was already created
+      const existingModelId = await checkIfModelExists(apiToken, envToPass)
+      const model = existingModelId
+        ? { id: existingModelId }
+        : await createSvgModel(apiToken, envToPass)
 
-      // Update plugin parameters with the model ID
+      // Migrate existing svgs to records before saving parameters
+      const svgsToMigrate = pluginParameters.svgs || []
+      if (svgsToMigrate.length > 0) {
+        await migrateSvgsToRecords(apiToken, model.id, svgsToMigrate)
+      }
+
+      // Save parameters without old svgs array to stay under size limit
+      const { svgs: _oldSvgs, ...restParams } = pluginParameters
       await ctx.updatePluginParameters({
-        ...pluginParameters,
+        ...restParams,
         svgModelId: model.id,
         isSetupComplete: true,
       })
 
-      ctx.notice('SVG model created successfully!')
+      const message =
+        svgsToMigrate.length > 0
+          ? `SVG model created and ${svgsToMigrate.length} SVG(s) migrated!`
+          : 'SVG model created successfully!'
+      ctx.notice(message)
     } catch (err) {
       console.error('Error creating model:', err)
       ctx.alert(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,10 +17,10 @@ import {
 import ConfigScreen from './entrypoints/ConfigScreen/ConfigScreen'
 import PageScreen from './entrypoints/PageScreen/PageScreen'
 import FieldExtensionConfigScreen from './entrypoints/FieldExtensionConfigScreen/FieldExtensionConfigScreen'
-import FieldExtension from './entrypoints/FieldExtension/FieldExtension'
 import CustomModal from './entrypoints/CustomModal/CustomModal'
 import { render } from './lib/render'
 import { GlobalParameters, PageType } from './lib/types'
+import FieldExtension from './entrypoints/FieldExtension/FieldExtension'
 import {
   contentAreaSidebarItemPlacement,
   customModalId,
@@ -32,8 +32,8 @@ import {
   placementOptions,
   settingsAreaSidebarItemPlacement,
 } from './lib/constants'
-import setUpdatedSvgArray from './lib/setUpdatedSvgArray'
 import { checkIfModelExists } from './lib/modelHelpers'
+import setUpdatedSvgArray from './lib/setUpdatedSvgArray'
 
 import './styles/index.css'
 
@@ -51,6 +51,7 @@ connect({
       // Check if the model already exists (in case setup was interrupted)
       const existingModelId = await checkIfModelExists(
         ctx.currentUserAccessToken!,
+        ctx.environment,
       )
 
       if (existingModelId) {

--- a/src/lib/modelHelpers.ts
+++ b/src/lib/modelHelpers.ts
@@ -74,8 +74,11 @@ export async function createSvgModel(apiToken: string, environment?: string) {
 
 export async function checkIfModelExists(
   apiToken: string,
+  environment?: string,
 ): Promise<string | null> {
-  const client = buildClient({ apiToken })
+  const config: ClientConfigOptions = { apiToken }
+  if (environment) config.environment = environment
+  const client = buildClient(config)
 
   try {
     const itemTypes = await client.itemTypes.list()


### PR DESCRIPTION
## Changes

**Fix setup and migration flow for existing projects**
<img width="1142" height="969" alt="Screenshot 2026-03-12 at 09 27 12" src="https://github.com/user-attachments/assets/e1d4c0b0-30af-46ce-987d-c7ccf1855109" />

The setup flow was broken for projects that already had SVGs stored in plugin parameters. This PR fixes:

- Check for existing SVG model before creating
- Pass environment to `checkIfModelExists` so it works on non primary environments
- Strip old `svgs` array from plugin parameters when saving to stay under 10KB limit
- Migrate SVGs to records during model creation so users don't lose data
- Handle partial migration failures with clear feedback