### PR TITLE
Fix migration by adding environment parameter

### DIFF
--- a/src/entrypoints/ConfigScreen/ConfigScreen.tsx
+++ b/src/entrypoints/ConfigScreen/ConfigScreen.tsx
@@ -149,7 +149,10 @@ export default function ConfigScreen({ ctx }: Props) {
       const apiToken = ctx.currentUserAccessToken!
 
       // Reuse existing model if it was already created
-      const existingModelId = await checkIfModelExists(apiToken, ctx.environment)
+      const existingModelId = await checkIfModelExists(
+        apiToken,
+        ctx.environment,
+      )
       const model = existingModelId
         ? { id: existingModelId }
         : await createSvgModel(apiToken, ctx.environment)

--- a/src/entrypoints/ConfigScreen/ConfigScreen.tsx
+++ b/src/entrypoints/ConfigScreen/ConfigScreen.tsx
@@ -97,16 +97,11 @@ export default function ConfigScreen({ ctx }: Props) {
         JSON.stringify(svgsToMigrate),
       )
 
-      const envToPass =
-        ctx.environment && !ctx.environment.includes('navigation')
-          ? ctx.environment
-          : undefined
-
       const migrated = await migrateSvgsToRecords(
         ctx.currentUserAccessToken!,
         pluginParameters.svgModelId,
         svgsToMigrate,
-        envToPass,
+        ctx.environment,
       )
 
       const failedCount = svgsToMigrate.length - migrated.length
@@ -153,17 +148,11 @@ export default function ConfigScreen({ ctx }: Props) {
     try {
       const apiToken = ctx.currentUserAccessToken!
 
-      // Only pass environment if it's not a UI navigation state
-      const envToPass =
-        ctx.environment && !ctx.environment.includes('navigation')
-          ? ctx.environment
-          : undefined
-
       // Reuse existing model if it was already created
-      const existingModelId = await checkIfModelExists(apiToken, envToPass)
+      const existingModelId = await checkIfModelExists(apiToken, ctx.environment)
       const model = existingModelId
         ? { id: existingModelId }
-        : await createSvgModel(apiToken, envToPass)
+        : await createSvgModel(apiToken, ctx.environment)
 
       // Migrate existing svgs to records before saving parameters
       const svgsToMigrate = pluginParameters.svgs || []
@@ -178,7 +167,7 @@ export default function ConfigScreen({ ctx }: Props) {
           apiToken,
           model.id,
           svgsToMigrate,
-          envToPass,
+          ctx.environment,
         )
         migratedCount = migrated.length
       }

--- a/src/entrypoints/ConfigScreen/ConfigScreen.tsx
+++ b/src/entrypoints/ConfigScreen/ConfigScreen.tsx
@@ -97,10 +97,16 @@ export default function ConfigScreen({ ctx }: Props) {
         JSON.stringify(svgsToMigrate),
       )
 
+      const envToPass =
+        ctx.environment && !ctx.environment.includes('navigation')
+          ? ctx.environment
+          : undefined
+
       const migrated = await migrateSvgsToRecords(
         ctx.currentUserAccessToken!,
         pluginParameters.svgModelId,
         svgsToMigrate,
+        envToPass,
       )
 
       const failedCount = svgsToMigrate.length - migrated.length
@@ -172,6 +178,7 @@ export default function ConfigScreen({ ctx }: Props) {
           apiToken,
           model.id,
           svgsToMigrate,
+          envToPass,
         )
         migratedCount = migrated.length
       }

--- a/src/lib/modelHelpers.ts
+++ b/src/lib/modelHelpers.ts
@@ -94,8 +94,11 @@ export async function migrateSvgsToRecords(
   apiToken: string,
   modelId: string,
   svgs: SvgUpload[],
+  environment?: string,
 ) {
-  const client = buildClient({ apiToken })
+  const config: ClientConfigOptions = { apiToken }
+  if (environment) config.environment = environment
+  const client = buildClient(config)
   const migratedRecords = []
 
   for (const svg of svgs) {


### PR DESCRIPTION
## Changes
We have some api errors since we're testing in another environment thats not the primary, so we're passing it now in the functions that needed

```
Everything SVG
SVG model created. 0 SVG(s) migrated successfully, but 33 failed. Check the browser console for details.

bundle.js:2 POST https://site-api.datocms.com/items 404 (Not Found)
```
<img width="1228" height="319" alt="Screenshot 2026-03-13 at 11 35 59" src="https://github.com/user-attachments/assets/08653ea4-d0c5-4be6-ba26-591a5e0a45f1" />
